### PR TITLE
Refactor Header to functional component and drop jQuery

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -9496,11 +9496,6 @@
         "supports-color": "^6.1.0"
       }
     },
-    "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -7,7 +7,6 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "antd": "^4.3.0",
-    "jquery": "^3.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1"

--- a/web-app/src/Components/Header/header.js
+++ b/web-app/src/Components/Header/header.js
@@ -1,89 +1,63 @@
-import React, { Component } from "react";
-import $ from 'jquery';
+import React, { useState, useEffect } from "react";
 import "./header.css";
 
+const Header = () => {
+  const [menuItems, setMenuItems] = useState([
+    { Title: "HOME", RouteURLPart: "#", ClassName: "selected" },
+    { Title: "SHOP", RouteURLPart: "#", ClassName: "not-selected" },
+    { Title: "LEARN", RouteURLPart: "#", ClassName: "not-selected" },
+    { Title: "ARTISTS", RouteURLPart: "#", ClassName: "not-selected" }
+  ]);
 
-class Header extends Component {
-  state = {
-    menuItems: [
-      {
-        Title: "HOME",RouteURLPart: "#",ClassName: "selected",
-      },
-      {
-        Title: "SHOP",RouteURLPart: "#",ClassName: "not-selected",
-      },
-      {
-        Title: "LEARN",RouteURLPart: "#",ClassName: "not-selected",
-      },
-      {
-        Title: "ARTISTS",RouteURLPart: "#",ClassName: "not-selected",
-      }
-    ]
+  const selectMenuItem = (menuItemName) => {
+    setMenuItems((items) =>
+      items.map((item) =>
+        item.Title === menuItemName
+          ? { ...item, ClassName: "selected" }
+          : { ...item, ClassName: "not-selected" }
+      )
+    );
   };
 
-  selectMenuItem(menuItemName) {
-    var items = this.state.menuItems;
-    for (var i = 0; i < items.length; i++) {
-      if(items[i].Title == menuItemName){
-        items[i].ClassName = "selected";
-      }else{
-        items[i].ClassName = "not-selected";
+  useEffect(() => {
+    const showHeaderAt = 150;
+    const handleScroll = () => {
+      if (window.scrollY > showHeaderAt) {
+        document.body.classList.add("fixed");
+      } else {
+        document.body.classList.remove("fixed");
       }
-    }
-    
-    this.setState({
-      menuItems:items  
-    })
-  }
+    };
 
-  render() {
-    return (
-      <header className="header-fixed">
-        <div className="header-limiter">
-          <h1>
-            <a href="#">
-              Art<span>Gallery</span>
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return (
+    <header className="header-fixed">
+      <div className="header-limiter">
+        <h1>
+          <a href="#">
+            Art<span>Gallery</span>
+          </a>
+        </h1>
+        <nav>
+          {menuItems.map((item) => (
+            <a
+              key={item.Title}
+              href={item.RouteURLPart}
+              className={item.ClassName}
+              onClick={() => selectMenuItem(item.Title)}
+            >
+              {item.Title}
             </a>
-          </h1>
-          <nav>
-            {this.state.menuItems.map((item) => (
-              <a
-                key={item.Title}
-                href={item.RouteURLPart}
-                className={item.ClassName}
-                onClick={() => this.selectMenuItem(item.Title)}
-              >
-                {item.Title}
-              </a>
-            ))}
-          </nav>
-        </div>
-      </header>
-    );
-  }
-
-  componentDidMount() {
-    $(document).ready(function () {
-      var showHeaderAt = 150;
-
-      var win = $(window),
-        body = $("body");
-
-      // Show the fixed header only on larger screen devices
-      if (win.width() > 600) {
-        // When we scroll more than 150px down, we set the
-        // "fixed" class on the body element.
-
-        win.on("scroll", function (e) {
-          if (win.scrollTop() > showHeaderAt) {
-            body.addClass("fixed");
-          } else {
-            body.removeClass("fixed");
-          }
-        });
-      }
-    });
-  }
-}
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+};
 
 export default Header;


### PR DESCRIPTION
## Summary
- convert Header to a functional component using hooks
- add scroll listener via useEffect and remove jQuery
- drop jquery dependency from package.json

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'define-property')*


------
https://chatgpt.com/codex/tasks/task_e_68b56d4c568c8330be8c7e80ab3ed4dc